### PR TITLE
Ajusta ambiente de testes para Issue #2

### DIFF
--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -1,8 +1,11 @@
-import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { renderToString } from 'react-dom/server'
 import App from './App'
 
-it('renderiza título', () => {
-  render(<App />)
-  expect(screen.getByText(/App DisÁgua/i)).toBeInTheDocument()
+describe('App', () => {
+  it('renderiza título', () => {
+    const html = renderToString(<App />)
+    expect(html).toContain('App DisÁgua')
+  })
 })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,21 @@
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@/components': resolve(__dirname, 'src/renderer/components'),
+      '@/lib': resolve(__dirname, 'src/renderer/lib')
+    }
+  },
   test: {
-    environment: 'jsdom',
+    environment: 'node',
     globals: true
   }
 })


### PR DESCRIPTION
## Summary
- atualiza o teste do componente App para usar renderização no servidor
- ajusta a configuração do Vitest para ambiente node e adiciona aliases compatíveis

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e68ce051408325837236adc2169300